### PR TITLE
DM-21426: Remove expectation that 'future' and 'wcslib' are dependencies.

### DIFF
--- a/python/lsst/ci/hsc/gen2/validate.py
+++ b/python/lsst/ci/hsc/gen2/validate.py
@@ -403,8 +403,8 @@ class VersionValidation(Validation):
         Validation.run(self, dataId, **kwargs)
 
         packages = self.butler.get("packages")  # No dataId needed
-        thirdparty = ['astropy', 'cfitsio', 'esutil', 'fftw', 'future', 'galsim', 'gsl', 'matplotlib',
-                      'numpy', 'python', 'scipy', 'wcslib']
+        thirdparty = ['astropy', 'cfitsio', 'esutil', 'fftw', 'galsim', 'gsl', 'matplotlib',
+                      'numpy', 'python', 'scipy']
         ours = ['afw', 'base', 'coadd_utils', 'daf_base', 'daf_persistence', 'ip_diffim', 'ip_isr',
                 'meas_algorithms', 'meas_astrom', 'meas_base', 'meas_deblender', 'meas_extensions_convolved',
                 'meas_extensions_photometryKron', 'meas_extensions_psfex', 'meas_extensions_shapeHSM',


### PR DESCRIPTION
It's not safe to assume these packages are dependencies of ci_hsc_gen2anymore, because they're only brought in as historical artifacts or via an optional extension.