### PR TITLE
DM-15536: Update SConstruct with correct Gen3 repo location.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -116,6 +116,7 @@ AddOption("--enable-profile", nargs="?", const="profile", dest="enable_profile",
 
 RAW = GetOption("raw")
 REPO = GetOption("repo")
+REPO_GEN3 = REPO + "gen3"
 CALIB = GetOption("calib")
 PROC = GetOption("repo") + " --rerun " + GetOption("rerun")  # Common processing arguments
 DATADIR = os.path.join(GetOption("repo"), "rerun", GetOption("rerun"))
@@ -437,7 +438,7 @@ consolidateObjectTable = command("consolidateObjectTable", [transformObjectCatal
                                   validate(ConsolidateObjectValidation, DATADIR, patchDataId,
                                            gen3id=patchGen3id)])
 
-gen3repo = env.Command([os.path.join(REPO, "butler.yaml"), os.path.join(REPO, "gen3.sqlite3")],
+gen3repo = env.Command([os.path.join(REPO_GEN3, "butler.yaml"), os.path.join(REPO, "gen3.sqlite3")],
                        [forcedPhotCcd, consolidateObjectTable],
                        "bin/gen2to3.sh")
 env.Alias("gen3repo", gen3repo)


### PR DESCRIPTION
This is leftover from a previous ticket, which switched the conversion mode from in-place to symlink, and I suspect this wasn't noticed because we don't really rely on SCons understanding the build dependencies completely here.