### PR TITLE
DM-25776: Fix type conversion of command-line data ID values to integer.

### DIFF
--- a/python/lsst/ci/hsc/gen2/validate.py
+++ b/python/lsst/ci/hsc/gen2/validate.py
@@ -91,7 +91,7 @@ def main():
     if args.id:
         intKeys = ["visit", "ccd", "tract"]
         if args.gen3:
-            intKeys.extend(["patch", "sensor", "exposure"])
+            intKeys.extend(["patch", "detector", "exposure"])
         for dataId in args.id:
             dataId = {key: int(value) if key in intKeys else value for
                       key, value in dataId.items()}


### PR DESCRIPTION
This has been broken a long time, but it's been masked by an unnecessary database lookup in daf_butler that went through some kind of SQLAlchemy and/or SQLite logic that treated integers as equal to their string equivalents.  That unnecessary database lookup has now been removed.