### PR TITLE
DM-27253: Use lsst.utils.tests.temporaryDirectory to avoid NFS cleanup issues.

### DIFF
--- a/tests/test_butlerShims.py
+++ b/tests/test_butlerShims.py
@@ -21,7 +21,6 @@
 
 import os
 import unittest
-from tempfile import TemporaryDirectory
 
 import lsst.utils.tests
 import lsst.afw.image.testUtils  # noqa; injects test methods into TestCase
@@ -142,7 +141,7 @@ class ButlerShimsTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(list(mergeDet2["id"]), list(mergeDet3["id"]))
 
     def testPut(self):
-        with TemporaryDirectory(dir=TESTDIR) as root:
+        with lsst.utils.tests.temporaryDirectory() as root:
             Butler3.makeRepo(root)
             butler3 = Butler3(root, run="three")
             butler3.registry.registerDatasetType(
@@ -155,10 +154,6 @@ class ButlerShimsTestCase(lsst.utils.tests.TestCase):
             butlerShim.put(catIn, "cat", htm7=131072)
             catOut = butlerShim.get("cat", htm7=131072)
             self.assertEqual(list(catIn["id"]), list(catOut["id"]))
-            # Without this the temporary directory can not be removed
-            # if on NFS because these objects have open SQLite registries.
-            del butler3
-            del butlerShim
 
 
 def setup_module(module):


### PR DESCRIPTION
The old code logic for working around NFS cleanup issues was not really rigorous, as it relied on Python GC'ing things immediately. And we already have a more rigorous fix in utils.

This is only on the branch for this particular ticket because changes in daf_butler seem to make the old approach reliably fail, probably due to some new closure-based reference cycles that Python doesn't unravel fast enough.
